### PR TITLE
ci: test build ichigo image

### DIFF
--- a/.github/workflows/build-ichigo-dockerimage.yml
+++ b/.github/workflows/build-ichigo-dockerimage.yml
@@ -1,4 +1,4 @@
-name: CI - Build Ichigo Image # Test CI
+name: CI - Build Ichigo Image
 on:
   pull_request:
     branches:

--- a/.github/workflows/build-ichigo-dockerimage.yml
+++ b/.github/workflows/build-ichigo-dockerimage.yml
@@ -1,4 +1,4 @@
-name: CI - Build Ichigo Image
+name: CI - Build Ichigo Image # Test CI
 on:
   pull_request:
     branches:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,3 +1,4 @@
+# test ci
 FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
 WORKDIR /code
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-ichigo-dockerimage.yml` file. The change updates the name of the CI build to include a comment indicating it is a test.