### PR TITLE
chore: correct typo deploy ichigo dockerhub

### DIFF
--- a/.github/workflows/deploy-ichigo-dockerhub.yml
+++ b/.github/workflows/deploy-ichigo-dockerhub.yml
@@ -22,4 +22,4 @@ jobs:
       context: api
       readme-file: ./README.md
       docker-repo-name: menloltd/ichigo
-      tags: menloltd/ichigo:{{ needs.get-tag.outputs.new_version }}
+      tags: menloltd/ichigo:${{ needs.get-tag.outputs.new_version }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy-ichigo-dockerhub.yml` file. The change corrects the syntax for referencing the `new_version` output in the `tags` field. 

* [`.github/workflows/deploy-ichigo-dockerhub.yml`](diffhunk://#diff-a7057327861b3c6d2d8d5442b97db9c5e4c2449e101d53acc69eda0379fd328dL25-R25): Changed the syntax from `{{ needs.get-tag.outputs.new_version }}` to `${{ needs.get-tag.outputs.new_version }}` for proper variable interpolation.