### PR TITLE
ci: add cicd pipeline for ichigo docs

### DIFF
--- a/.github/workflows/clean-cloudflare-page-preview-url-and-r2.yml
+++ b/.github/workflows/clean-cloudflare-page-preview-url-and-r2.yml
@@ -1,0 +1,51 @@
+name: "Clean old cloudflare pages preview urls and nightly build"
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day at 00:00
+  workflow_dispatch:
+
+jobs:
+  clean-cloudflare-pages-preview-urls:
+    strategy:
+      matrix:
+        project: ["ichigo"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: install requests
+        run: |
+          python3 -m pip install requests pytz tqdm
+      - name: Python Inline script
+        uses: jannekem/run-python-script-action@v1
+        with: 
+          script: |
+            import requests
+            from datetime import datetime, UTC
+            from pytz import timezone
+            from tqdm import tqdm
+            
+            # Configuration
+            endpoint = "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/pages/projects/${{ matrix.project }}/deployments"
+            expiration_days = 3
+            headers = {
+                "Content-Type": "application/json;charset=UTF-8",
+                "Authorization": "Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}"
+            }
+            utc_tz = timezone('UTC')
+
+            # Fetch the list of deployments
+            response = requests.get(endpoint, headers=headers)
+            deployments = response.json()
+
+            for deployment in tqdm(deployments['result']):
+                # Calculate the age of the deployment
+                created_on = datetime.strptime(deployment['created_on'], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=utc_tz)
+                if (datetime.now(UTC) - created_on).days > expiration_days:
+                    # Delete the deployment
+                    delete_response = requests.delete(f"{endpoint}/{deployment['id']}", headers=headers)
+                    if delete_response.status_code == 200:
+                        print(f"Deleted deployment: {deployment['id']}")
+                    else:
+                        print(f"Failed to delete deployment: {deployment['id']}")

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -52,9 +52,14 @@ jobs:
       - name: Install dependencies
         working-directory: docs
         run: yarn install
+    
       - name: Build website
         working-directory: docs
-        run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects
+        run: export NODE_ENV=production && yarn build
+        
+      - name: Copy redirect file
+        continue-on-error: true
+        run: cp _redirects build/_redirects
 
       - name: Publish to Cloudflare Pages PR Preview and Staging
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -3,16 +3,19 @@ name: Menlo Ichigo
 on:
   push:
     branches:
-      - main
+      - dev
+    paths:
+      - 'docs/**'
   pull_request:
+    paths:
+      - 'docs/**'
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
-  schedule:
-    - cron: "0 22 * * 1,2,3,4,5,6"
+  workflow_dispatch:
 
 jobs:
   deploy:
-    name: Deploy to Cloudflare Pages
+    name: Deploy to CloudFlare Pages
     env:
       CLOUDFLARE_PROJECT_NAME: ichigo
     runs-on: ubuntu-latest
@@ -26,11 +29,11 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install jq
+      - name: Install jq      
         uses: dcarbone/install-jq-action@v2.0.1
 
       - name: Fill env vars
-        continue-on-error: true
+        working-directory: docs
         run: |
           env_example_file=".env.example"
           touch .env
@@ -43,16 +46,14 @@ jobs:
             fi
           done < "$env_example_file"
         env:
-          SECRETS: "${{ toJson(secrets) }}"
+          SECRETS: '${{ toJson(secrets) }}'
 
       - name: Install dependencies
-        run: npm install
+        working-directory: docs
+        run: yarn install
       - name: Build website
-        run: export NODE_ENV=production && npm run build
-
-      - name: Copy redirect file
-        continue-on-error: true
-        run: cp _redirects build/_redirects
+        working-directory: docs
+        run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects
 
       - name: Publish to Cloudflare Pages PR Preview and Staging
         if: github.event_name == 'pull_request'
@@ -61,7 +62,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
-          directory: ./out
+          directory: ./docs/out
           # Optional: Enable this if you want to have GitHub Deployments triggered
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
         id: deployCloudflarePages
@@ -70,16 +71,16 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           message: |
-            Preview URL: ${{ steps.deployCloudflarePages.outputs.url }}
+              Preview URL: ${{ steps.deployCloudflarePages.outputs.url }}
 
       - name: Publish to Cloudflare Pages Production
-        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && github.event.pull_request.head.repo.full_name != github.repository
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/dev') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
-          directory: ./out
+          directory: ./docs/out
           branch: main
           # Optional: Enable this if you want to have GitHub Deployments triggered
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,0 +1,85 @@
+name: Menlo Ichigo
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+  schedule:
+    - cron: "0 22 * * 1,2,3,4,5,6"
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    env:
+      CLOUDFLARE_PROJECT_NAME: ichigo
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.0.1
+
+      - name: Fill env vars
+        continue-on-error: true
+        run: |
+          env_example_file=".env.example"
+          touch .env
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            if [[ "$line" == *"="* ]]; then
+              var_name=$(echo $line | cut -d '=' -f 1)
+              echo $var_name
+              var_value="$(jq -r --arg key "$var_name" '.[$key]' <<< "$SECRETS")"
+              echo "$var_name=$var_value" >> .env
+            fi
+          done < "$env_example_file"
+        env:
+          SECRETS: "${{ toJson(secrets) }}"
+
+      - name: Install dependencies
+        run: npm install
+      - name: Build website
+        run: export NODE_ENV=production && npm run build
+
+      - name: Copy redirect file
+        continue-on-error: true
+        run: cp _redirects build/_redirects
+
+      - name: Publish to Cloudflare Pages PR Preview and Staging
+        if: github.event_name == 'pull_request'
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
+          directory: ./out
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        id: deployCloudflarePages
+
+      - uses: mshick/add-pr-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          message: |
+            Preview URL: ${{ steps.deployCloudflarePages.outputs.url }}
+
+      - name: Publish to Cloudflare Pages Production
+        if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ env.CLOUDFLARE_PROJECT_NAME }}
+          directory: ./out
+          branch: main
+          # Optional: Enable this if you want to have GitHub Deployments triggered
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -3,7 +3,7 @@ name: Menlo Ichigo
 on:
   push:
     branches:
-      - dev
+      - main
     paths:
       - 'docs/**'
   pull_request:

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -33,6 +33,7 @@ jobs:
         uses: dcarbone/install-jq-action@v2.0.1
 
       - name: Fill env vars
+        continue-on-error: true
         working-directory: docs
         run: |
           env_example_file=".env.example"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,4 +1,4 @@
-# Docker
+# Docker - Test CICD
 
 1. Pull the container from Docker Hub
 

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -5,4 +5,16 @@ const withNextra = nextra({
   themeConfig: "./theme.config.tsx",
 });
 
-export default withNextra();
+const nextConfig = {
+  reactStrictMode: true,
+  output: "export",
+  env: {
+    GTM_ID: process.env.GTM_ID,
+  },
+  images: {
+    formats: ["image/webp"],
+    unoptimized: true,
+  },
+};
+
+export default withNextra(nextConfig);


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to manage Cloudflare Pages deployments and clean up old preview URLs. The most important changes include the creation of workflows for nightly cleanup and deployment to Cloudflare Pages.

New GitHub Actions workflows:

* [`.github/workflows/clean-cloudflare-page-preview-url-and-r2.yml`](diffhunk://#diff-898a705fa8fb9d04143afeff910f5f904408321d359cfc8ce239552c29c6198fR1-R51): Added a workflow to clean old Cloudflare Pages preview URLs and perform nightly builds. This workflow runs daily at midnight and includes steps for setting up Python, installing dependencies, and executing a Python script to delete old deployments.
* [`.github/workflows/cloudflare-pages.yml`](diffhunk://#diff-621c8dd82c4542a6b9aed47391aec693a882b73039ebcdd55bfcc03e55ebc349R1-R85): Added a workflow to deploy to Cloudflare Pages on push to the main branch, pull requests, and a scheduled basis. This workflow sets up the environment, installs dependencies, builds the website, and publishes it to Cloudflare Pages.