### PR TITLE
ci: update publish to cloudflare pages production job

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -80,7 +80,7 @@ jobs:
               Preview URL: ${{ steps.deployCloudflarePages.outputs.url }}
 
       - name: Publish to Cloudflare Pages Production
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/dev') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the `jobs` section in the `.github/workflows/cloudflare-pages.yml` file. The change updates the condition for publishing to Cloudflare Pages Production to trigger on the `main` branch instead of the `dev` branch.

* [`.github/workflows/cloudflare-pages.yml`](diffhunk://#diff-621c8dd82c4542a6b9aed47391aec693a882b73039ebcdd55bfcc03e55ebc349L83-R83): Updated the branch condition for the production deployment from `dev` to `main`.