### PR TITLE
chore: update docsRepositoryBase and project link

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -7,13 +7,14 @@ const config: DocsThemeConfig = {
     <span className="flex gap-x-8 items-center">
       <div className="flex">
         {/* <LogoMark /> */}
-        <span className="ml-2 font-semibold">Menlo Guide</span>
+        <span className="ml-2 font-semibold">Menlo Ichigo</span>
       </div>
     </span>
   ),
   project: {
-    link: "https://github.com/janhq/guide",
+    link: "https://github.com/janhq/ichigo",
   },
+  docsRepositoryBase: "https://github.com/janhq/ichigo/tree/main/docs",
   footer: {
     content: (
       <span>


### PR DESCRIPTION
This pull request includes updates to the `docs/theme.config.tsx` file to reflect changes in project naming and repository links.

Branding and repository link updates:

* Updated the project name from "Menlo Guide" to "Menlo Ichigo".
* Changed the project link to point to the new repository URL `https://github.com/janhq/ichigo`.
* Added `docsRepositoryBase` to point to the new documentation base URL `https://github.com/janhq/ichigo/tree/main/docs`.