### PR TITLE
fix: Explicitly load checkpoint to CPU to avoid CUDA error

### DIFF
--- a/ichigo/asr/transcriber.py
+++ b/ichigo/asr/transcriber.py
@@ -27,7 +27,7 @@ def load_quantizer(ref, config):
     else:
         local_filename = ref
 
-    spec = torch.load(local_filename)
+    spec = torch.load(local_filename, map_location="cpu")
     model_state_dict = {
         k.replace("model.", ""): v for k, v in spec["state_dict"].items()
     }


### PR DESCRIPTION
The checkpoint was serialized directly from CUDA tensors. Hence, by default, `torch.load()` will attempt to reload the weights to CUDA, even if CUDA is not available e.g. CPU-only machines.

Without this fix, on my macbook, I'm getting this error

> RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.

This PR fixes it.
